### PR TITLE
fix: Match observer notify events by prefix instead of substring

### DIFF
--- a/src/observer.rs
+++ b/src/observer.rs
@@ -285,11 +285,11 @@ async fn staff(
         return Processor::user_left(line, argument, client_map).await;
     }
 
-    if line.contains("notifyclientmoved") && argument.monitor_channel().valid() {
+    if line.starts_with("notifyclientmoved") && argument.monitor_channel().valid() {
         return Processor::user_move(line, argument).await;
     }
 
-    if line.contains("notifytextmessage") && argument.monitor_channel().valid() {
+    if line.starts_with("notifytextmessage") && argument.monitor_channel().valid() {
         return Processor::user_text(line, argument).await;
     }
     if line.starts_with("banid") {
@@ -371,7 +371,9 @@ pub async fn observer_thread(
             message = tokio::time::timeout(Duration::from_millis(interval), recv.recv()) => {
                 let message = match message {
                     Ok(Some(ret)) => ret,
-                    _ => continue,
+                    // All senders has been dropped, no more message will arrive
+                    Ok(None) => break,
+                    Err(_) => continue,
                 };
                 match message {
                     PrivateMessageRequest::Message(client_id, message) => {


### PR DESCRIPTION
## Problem

The observer event dispatcher in `staff()` used `line.contains("notifyclientmoved")`:

```rust
if line.contains("notifyclientmoved") && argument.monitor_channel().valid() {
    return Processor::user_move(line, argument).await;
}
```

A `notifytextmessage` line whose message body contains that substring is routed into `user_move`, where `NotifyClientMovedView::from_query` fails because a text-message line has no `ctid` field. The error propagates through `?`, `observer_thread` returns `Err`, and the whole process exits.

**Impact:** any TeamSpeak user can crash the service by sending the observer bot a single private message containing the substring `notifyclientmoved` (repeatable under systemd → restart loop).

## Fix

- Dispatch all notify events with `starts_with` instead of `contains`.
- Also `break` the observer loop when the private-message channel closes (`Ok(None)`) instead of `continue`; `recv()` then returns `None` immediately on every iteration, turning the loop into a busy spin.
