### PR TITLE
fix: Handle unknown client left reason without panic

### DIFF
--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -76,7 +76,11 @@ mod types {
                             }
                         )
                     }
-                    _ => unreachable!("Got unexpected left message: {view:?}"),
+                    reason => write!(
+                        f,
+                        "[{time}] <b>{nickname}</b>({}) left with unknown reason id {reason}",
+                        view.client_id()
+                    ),
                 },
             }
         }


### PR DESCRIPTION
## Problem

The `Display` impl for `TelegramData::Left` matched reason ids 8, 3, 5 and 6 and panicked via `unreachable!()` for anything else:

```rust
_ => unreachable!("Got unexpected left message: {view:?}"),
```

TeamSpeak emits other reason ids as well (for example when the virtual server is stopped), and the release profile uses `panic = "abort"`, so this aborts the whole process instead of formatting a notification.

## Fix

Render an explicit `left with unknown reason id N` line for unrecognized reason ids.
