### PR TITLE
fix: Keep partial socket reads across observer loop cancellations

### DIFF
--- a/src/socketlib.rs
+++ b/src/socketlib.rs
@@ -13,6 +13,11 @@ const BUFFER_SIZE: usize = 512;
 
 pub struct SocketConn {
     conn: TcpStream,
+    /// Data already read from the socket but not yet returned to the caller.
+    ///
+    /// Keeping it here makes `read_inner` cancellation-safe: dropping the
+    /// future mid-read no longer discards the bytes received so far.
+    pending: String,
 }
 
 impl SocketConn {
@@ -38,7 +43,6 @@ impl SocketConn {
         is_complete: impl Fn(&str, usize) -> bool,
     ) -> anyhow::Result<Option<String>> {
         let mut buffer = [0u8; BUFFER_SIZE];
-        let mut ret = String::new();
         loop {
             let size = match timeout {
                 Some(dur) => match tokio::time::timeout(dur, self.conn.read(&mut buffer)).await {
@@ -55,12 +59,13 @@ impl SocketConn {
             if size == 0 {
                 return Ok(None);
             }
-            ret.push_str(&String::from_utf8_lossy(&buffer[..size]));
-            if is_complete(&ret, size) {
+            self.pending
+                .push_str(&String::from_utf8_lossy(&buffer[..size]));
+            if is_complete(&self.pending, size) {
                 break;
             }
         }
-        Ok(Some(ret))
+        Ok(Some(std::mem::take(&mut self.pending)))
     }
 
     pub async fn read_event(&mut self) -> anyhow::Result<Option<String>> {
@@ -168,7 +173,10 @@ impl SocketConn {
 
         //let bufreader = BufReader::new(conn);
         //conn.set_nonblocking(true).unwrap();
-        let mut self_ = Self { conn };
+        let mut self_ = Self {
+            conn,
+            pending: String::new(),
+        };
 
         let content = self_
             .read_data()
@@ -178,6 +186,10 @@ impl SocketConn {
         if content.is_none() {
             warn!("Read none data.");
         }
+
+        // The greeting banner is not needed, drop any partially read leftover
+        // so it cannot corrupt the first command response.
+        self_.pending.clear();
 
         Ok(self_)
     }


### PR DESCRIPTION
## Problem

`read_inner` accumulated received bytes in a local `String`:

```rust
let mut ret = String::new();
loop {
    let size = ...read...;
    ret.push_str(&String::from_utf8_lossy(&buffer[..size]));
    if is_complete(&ret, size) { break; }
}
```

In the observer loop, `read_event()` lives inside `tokio::select!` and is dropped and recreated whenever the other branch wins — on every private message tick and every `interval` timeout (default **5 ms**). If the future had already consumed bytes of an event that spans multiple TCP segments, those bytes are discarded. The next read starts mid-event, producing truncated or corrupted lines that fail to parse, and the parse error propagates through `?` and terminates the process.

The trigger is correlated with real traffic: when a user joins, auto channel moves them and sends a private message through the mpsc channel exactly while `notifyclientmoved` events for that user are in flight on the observer socket.

## Fix

- Move the accumulation buffer into `SocketConn` (`pending: String`) so a cancelled read resumes from the leftover bytes instead of losing them.
- Clear the buffer after the greeting banner in `connect()` so a partially received banner cannot be prepended to the first command response.

Within a single poll the read → append → completeness-check sequence is synchronous, so only genuinely incomplete data is ever left buffered; there is no added latency for complete events.
