### PR TITLE
fix: Return error instead of panicking on empty query results

### DIFF
--- a/src/auto_channel.rs
+++ b/src/auto_channel.rs
@@ -272,7 +272,12 @@ pub async fn auto_channel_staff(
                             error!("[{thread_id}] Got error while create {name:?} channel: {e:?}",);
                             continue 'outer;
                         }
-                        _ => unreachable!(),
+                        Ok(None) => {
+                            error!(
+                                "[{thread_id}] Got empty response while create {name:?} channel",
+                            );
+                            continue 'outer;
+                        }
                     };
 
                     break create_channel;

--- a/src/socketlib.rs
+++ b/src/socketlib.rs
@@ -131,10 +131,7 @@ impl SocketConn {
         payload: &str,
     ) -> QueryResult<Vec<T>> {
         let data = self.write_and_read(payload).await?;
-        let ret = Self::decode_status_with_result(data)?;
-        Ok(ret
-            .ok_or_else(|| panic!("Can't find result line, payload => {payload}"))
-            .unwrap())
+        Self::decode_status_with_result(data)?.ok_or_else(QueryError::static_empty_response)
     }
 
     async fn query_operation<T: FromQueryString + Sized>(
@@ -152,7 +149,7 @@ impl SocketConn {
     ) -> QueryResult<Option<T>> {
         self.query_operation(payload)
             .await
-            .map(|r| r.map(|mut v| v.swap_remove(0)))
+            .map(|r| r.and_then(|v| v.into_iter().next()))
     }
 
     fn escape(s: &str) -> String {


### PR DESCRIPTION
## Problem

Two panic paths on responses that are unusual but legitimate:

- `query_operation_non_error` did `.ok_or_else(|| panic!("Can't find result line, payload => {payload}")).unwrap()` when a command came back without a data line.
- `query_one_operation` called `v.swap_remove(0)` on a possibly empty vector.

Because the release profile uses `panic = "abort"`, a single status-only response (for example `clientlist` racing a server restart) aborted the whole process instead of surfacing a `QueryError`.

Additionally `auto_channel` had an `unreachable!()` for a status-only `channelcreate` response.

## Fix

- Return `QueryError::static_empty_response()` when the data line is missing.
- Use `into_iter().next()` so an empty result maps to `Ok(None)` instead of panicking.
- Replace the `channelcreate` `unreachable!()` with a logged skip of the affected client.
