### PR TITLE
fix: Register empty user state for configs with invalid telegram token

### DIFF
--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -286,6 +286,7 @@ mod thread {
             // Get bot self ID
             let Some((bot_id, _)) = config.telegram().api_key().split_once(':') else {
                 warn!("Configure: [{config_id}] token in invalid format, ignore.",);
+                user_state_map.insert(config_id, SafeUserState::create_none());
                 continue;
             };
 


### PR DESCRIPTION
## Problem

A non-empty `api-key` without a `:` made `telegram_bootstrap` skip the config **without** inserting it into `user_state_map`. `bootstrap_controller` later does:

```rust
let map = user_state_map.get(&config.get_id()).unwrap().clone();
```

so a malformed token aborted the process at startup with an unhelpful panic instead of just disabling telegram for that server.

## Fix

Insert a `SafeUserState::create_none()` before the `continue`, matching the empty-key path.
