### PR TITLE
fix: Record consistent identifiers in tracker

### DIFF
--- a/src/observer.rs
+++ b/src/observer.rs
@@ -211,12 +211,7 @@ mod processor {
             #[cfg(feature = "tracker")]
             argument
                 .tracker_controller()
-                .insert(
-                    view.client_id() as i32,
-                    Some(view.invoker_uid().to_string()),
-                    Some(view.invoker_name().to_string()),
-                    Some(view.channel_id() as i32),
-                )
+                .insert(view.client_id() as i32, None, None, Some(view.channel_id() as i32))
                 .await
                 .tap_none(|| warn!("[{}] Unable send message to tracker", argument.thread_id()));
             Ok(())
@@ -343,7 +338,7 @@ pub async fn observer_thread(
         tracker_controller
             .insert(
                 client.client_id() as i32,
-                Some(client.client_database_id().to_string()),
+                Some(client.client_unique_identifier().to_string()),
                 Some(client.client_nickname().to_string()),
                 Some(client.channel_id() as i32),
             )

--- a/src/plugins/tracker.rs
+++ b/src/plugins/tracker.rs
@@ -57,7 +57,7 @@ async fn create_new_database(conn: &mut SqliteConnection) -> DatabaseResult<()> 
 }
 
 async fn insert_database_version(conn: &mut SqliteConnection) -> DatabaseResult<()> {
-    sqlx::query(r#"INSERT INTO "meta" VALUES ("version", ?)"#)
+    sqlx::query(r#"INSERT INTO "meta" VALUES ('version', ?)"#)
         .bind(VERSION)
         .execute(conn)
         .await

--- a/src/socketlib.rs
+++ b/src/socketlib.rs
@@ -253,7 +253,8 @@ impl SocketConn {
     }
 
     pub(crate) async fn query_clients(&mut self) -> QueryResult<Vec<Client>> {
-        self.query_operation_non_error("clientlist\n\r").await
+        // -uid is required so Client::client_unique_identifier is always present
+        self.query_operation_non_error("clientlist -uid\n\r").await
     }
 
     pub(crate) async fn move_client(

--- a/src/types.rs
+++ b/src/types.rs
@@ -124,6 +124,7 @@ mod client {
         client_database_id: i64,
         client_type: i64,
         client_nickname: String,
+        client_unique_identifier: String,
     }
 
     impl Client {
@@ -141,6 +142,9 @@ mod client {
         }
         pub fn client_nickname(&self) -> &str {
             &self.client_nickname
+        }
+        pub fn client_unique_identifier(&self) -> &str {
+            &self.client_unique_identifier
         }
         pub fn client_is_user(&self) -> bool {
             self.client_type == 0
@@ -215,12 +219,6 @@ pub mod notifies {
         reason_id: i64,
         #[serde(rename = "invokerid", default)]
         invoker_id: i64,*/
-        #[cfg(feature = "tracker")]
-        #[serde(rename = "invokeruid", default)]
-        invoker_uid: String,
-        #[cfg(feature = "tracker")]
-        #[serde(rename = "invokername", default)]
-        invoker_name: String,
         #[serde(rename = "clid", default)]
         client_id: i64,
     }
@@ -235,14 +233,6 @@ pub mod notifies {
         pub fn invoker_id(&self) -> i64 {
             self.invoker_id
         }*/
-        #[cfg(feature = "tracker")]
-        pub fn invoker_uid(&self) -> &str {
-            &self.invoker_uid
-        }
-        #[cfg(feature = "tracker")]
-        pub fn invoker_name(&self) -> &str {
-            &self.invoker_name
-        }
         pub fn client_id(&self) -> i64 {
             self.client_id
         }


### PR DESCRIPTION
## Problem

The `users.id` column received three different identities:

| Source | Recorded as |
|---|---|
| Startup snapshot (`clientlist`) | numeric `client_database_id` string |
| `notifycliententerview` | `client_unique_identifier` |
| `notifyclientmoved` | the **invoker's** uid and name |

The move case attributed a move to whoever caused it (empty for self-moves) instead of the moved client, and the mixed id schemes made membership queries against the table wrong.

## Fix

- Request `clientlist -uid` so the unique identifier is always available (new `client_unique_identifier` field on `Client`, already present in the existing test fixture).
- Use the unique identifier in the startup snapshot.
- Record only the moved client (`clid` + target channel, id/nickname unknown in the event) for move events; remove the now-unused invoker fields from `NotifyClientMovedView`.

Also switch the version key in the `meta` insert from `"version"` to `'version'`; the double-quoted form only works through SQLite's double-quoted-string fallback and fails on DQS-disabled builds.
