### PR TITLE
fix: Bound pending telegram message queue

### DIFF
--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -254,6 +254,11 @@ mod thread {
 
     const QUERY_BOT_ERROR: &str = "Query bot error";
 
+    /// Upper bound of unsent messages kept per bot, the oldest entries are
+    /// dropped when exceeded so a prolonged send failure cannot grow the
+    /// queue without limit.
+    const MAX_PENDING_MESSAGES: usize = 1024;
+
     pub fn telegram_bootstrap(
         configs: &Vec<(String, Config)>,
         notifier: Arc<Notify>,
@@ -364,11 +369,13 @@ mod thread {
                         break;
                     };
                     if let Some(bot_id) = config_map.get(&config_id) {
-                        bot_map
-                            .get_mut(bot_id)
-                            .expect(QUERY_BOT_ERROR)
-                            .1
-                            .push((config_id, data));
+                        let (_, queue) = bot_map.get_mut(bot_id).expect(QUERY_BOT_ERROR);
+                        queue.push((config_id, data));
+                        if queue.len() > MAX_PENDING_MESSAGES {
+                            let overflow = queue.len() - MAX_PENDING_MESSAGES;
+                            queue.drain(..overflow);
+                            warn!("Dropped {overflow} pending telegram messages for {bot_id}");
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Problem

Failed telegram sends are retried on the next 1-second tick with no cap, and the per-bot queue is only cleared when `channel_id == 0`. An extended telegram outage therefore grew the pending queue (one entry per join/leave event) without limit — a slow memory leak.

## Fix

Cap the queue at 1024 entries per bot; the oldest entries are dropped and the drop is logged.
